### PR TITLE
Phase 1: Persist B+ Tree to disk via IndexManager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ include_directories(include)
 # Source files
 set(SOURCES
     src/bplustree.cpp
+    src/indexmanager.cpp
     src/node.cpp
     src/pagemanager.cpp
     src/record.cpp

--- a/CODEGUIDE.md
+++ b/CODEGUIDE.md
@@ -20,10 +20,10 @@ build\db_engine_test.exe
 | **PageManager** | `pagemanager.hpp`, `pagemanager.cpp` | File I/O for pages. Allocate, read, write by page_id. Opens file on construction. |
 | **RecordManager** | `recordmanager.hpp`, `recordmanager.cpp` | Insert/read/delete Record objects using PageManager. Auto-allocates pages. |
 | **BPlusTreeNode** | `node.hpp`, `node.cpp` | Node with keys + RIDs (leaf) or keys + children (internal). Split, merge, serialize. |
-| **BPlusTree** | `bplustree.hpp`, `bplustree.cpp` | In-memory B+ tree index. Insert, search, update, rangeScan, remove. |
+| **BPlusTree** | `bplustree.hpp`, `bplustree.cpp` | B+ tree index with optional disk persistence. Insert, search, update, rangeScan, remove, save, load. |
 | **CatalogManager** | `catalogmanager.hpp`, `catalogmanager.cpp` | Table schema catalog. Saves/loads from text file. |
 | **Table** | `table.hpp`, `table.cpp` | High-level API combining RecordManager + BPlusTree. Insert/getByKey/deleteByKey. |
-| **IndexManager** | `indexmanager.hpp` | NOT USED. Stub for persisting B+ tree to disk. |
+| **IndexManager** | `indexmanager.hpp`, `indexmanager.cpp` | Persists B+ tree nodes to disk. Allocates node IDs, saves/loads individual nodes, stores root_node_id header. |
 | **constants.hpp** | — | ORDER, PAGE_SIZE, RID struct. |
 
 ## Key Patterns
@@ -64,7 +64,9 @@ Uses `passed`/`failed` globals with try/catch. No test framework dependency.
 - `BPlusTree::remove()` has underflow handling but no rebalancing for root-as-leaf edge case fully tested
 - `RecordManager::insertRecord()` scans all existing pages linearly before allocating new
 - `Table::deleteByKey()` calls `BPlusTree::remove()` which is the `remove` method
-- `IndexManager` exists but is never wired up — B+ tree is entirely in-memory
+- `IndexManager` stores a 4-byte `root_node_id` header at offset 0; nodes start at offset `PAGE_SIZE`
+- `BPlusTree(IndexManager&)` auto-loads; `save()` persists the entire tree; `load()` reconstructs `next_leaf` chain
+- `IndexManager::loadNode()` returns stubs for internal-node children — `BPlusTree::load()` recursively loads them
 
 ## PR Workflow
 1. Branch from `main`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # B+ Tree Database Engine
 
-A minimal database engine written in C++17 with B+ tree indexing, page-based storage, and catalog management.
+A minimal database engine written in C++17 with B+ tree indexing, page-based storage, disk-persistent indexes, and catalog management.
 
 ## Quick Start
 
@@ -36,8 +36,9 @@ Everything you need is in [`AGENTS.md`](./AGENTS.md):
 
 ## Features
 
-- B+ Tree index (key-based search, insert, delete, range scan)
+- B+ Tree index (key-based search, insert, delete, range scan, persistence)
 - Page-based disk storage with slot directories
 - Record CRUD (insert, read, delete by key)
 - Persistent catalog (table schemas saved to file)
+- B+ tree survives process restarts (serialized to disk via `IndexManager`)
 - Modular design: index / storage / catalog / schema are decoupled

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,112 @@
+# DB Engine Roadmap
+
+## Guiding principle
+Each phase builds on the previous. Every phase is independently demo-able in an interview.
+
+---
+
+## Phase 1: Persist the B+ Tree  (≈ 2-3 coding sessions)
+**What:** Wire up `IndexManager` so the B+ tree survives process restarts.
+**Why:** Currently the tree is in-memory — lose power, lose the index. This is the #1 gap.
+
+**Plan:**
+- `BPlusTree` gets a `save()` / `load(IndexManager&)` or a constructor that takes `IndexManager&` and auto-loads
+- On every insert/remove/update, persist the affected nodes (or lazy-write on flush)
+- `IndexManager` already has `loadNode`, `saveNode`, `allocateNodeID` — just needs connecting
+- Add a test that inserts 20 keys, destroys the tree, reloads from disk, asserts all keys survive
+
+**Systems concept taught:** Serialization, disk layout, the memory-storage boundary.
+
+---
+
+## Phase 2: Buffer Pool (≈ 3-4 sessions)
+**What:** Replace the current `PageManager` (read/write every call) with a fixed-size page cache using clock-sweep or LRU.
+**Why:** The #1 performance problem. Every `readPage`/`writePage` hits disk.
+
+**Plan:**
+- `BufferPool` class owns N frames (e.g., 64 frames × 4 KB = 256 KB cache)
+- Each frame: `Page` + `page_id` + `dirty_flag` + `pin_count` + `last_access`
+- `fetchPage(page_id)` — return from cache or read from disk; pin it
+- `unpinPage(page_id, dirty)` — release pin; if dirty, mark for eventual write
+- Eviction policy: Clock sweep (simpler than LRU, still shows you understand)
+- `flush()` — write all dirty pages back to disk
+- Refactor `PageManager` to use `BufferPool` underneath (or replace it entirely)
+
+**Systems concept taught:** Locality of reference, caching, the pin/unpin contract, eviction policy trade-offs.
+
+---
+
+## Phase 3: Write-Ahead Log (≈ 3-4 sessions)
+**What:** Before modifying any page, append a log record. On crash recovery, replay committed changes and undo uncommitted ones.
+**Why:** Durability. Without it, a crash mid-write corrupts the database.
+
+**Plan:**
+- Log format: `LSN | prev_LSN | txn_id | page_id | offset | old_data | new_data` (or simpler: `page_id | before_image | after_image`)
+- `WALWriter` — append-only sequential file
+- Every `BufferPool::unpinPage(dirty=true)` forces a log write first (WAL rule: write-ahead)
+- Recovery: read log forward; redo all changes; undo incomplete txns by writing before-images
+- Test: write records, corrupt the DB file (simulate crash), restart, assert data is intact
+
+**Systems concept taught:** ARIES fundamentals, REDO/UNDO, crash recovery, the write-ahead invariant.
+
+---
+
+## Phase 4: Simple Transactions (≈ 2-3 sessions)
+**What:** `BEGIN`, `COMMIT`, `ROLLBACK` with row-level locking.
+**Why:** Concurrency control — the other half of ACID.
+
+**Plan:**
+- `Transaction` class: `txn_id`, `state` (ACTIVE/COMMITTED/ABORTED), `lock_set`
+- Lock manager: shared (read) / exclusive (write) locks on RIDs
+- Deadlock detection: timeout or waits-for graph
+- On `ROLLBACK`: apply UNDO using the WAL
+- Test: two threads inserting simultaneously; no lost updates, no dirty reads
+
+**Systems concept taught:** Isolation levels, 2PL, deadlock, serializability.
+
+---
+
+## Phase 5: SQL Frontend (≈ 4-5 sessions)
+**What:** Accept SQL over TCP and execute it.
+**Why:** This is the "oh you built a database" moment.
+
+**Plan:**
+- Simple recursive-descent parser: `SELECT/INSERT/CREATE TABLE/DELETE` with WHERE clause (single condition)
+- AST → query plan
+- Execution: bind to `Table` API, filter rows, project columns
+- Wire protocol: simple `\n`-delimited text over TCP (no need for PostgreSQL wire protocol)
+- Single-threaded at first, then add connection pool
+
+**Systems concept taught:** Parsing, query planning, iterator model (next time), client-server architecture.
+
+---
+
+## Phase 6: Benchmarking & Polish (ongoing)
+**What:** Measure and optimize.
+**Why:** Numbers on a resume.
+
+**Plan:**
+- Insert throughput (rows/s), point lookup latency, range scan speed
+- YCSB-style workload A (50% read / 50% update)
+- Compare: no buffer pool vs. buffer pool → shows your cache works
+- fuzz testing: random operations, assert no crash
+
+---
+
+## Interview Story Arc
+
+| Phase | You can say |
+|-------|-------------|
+| 1 | "I serialized a B+ tree to disk so indexes survive crashes" |
+| 2 | "I built an LRU buffer pool to cache pages and reduce disk I/O by 100x" |
+| 3 | "I implemented a write-ahead log with crash recovery" |
+| 4 | "I added transactions with row-level locking and deadlock detection" |
+| 5 | "I wrote a SQL parser and a TCP server so clients can query the database" |
+
+Each phase builds a sentence you can say in an interview. No fluff.
+
+---
+
+## Recommendation
+
+Start with **Phase 1** — it's the smallest change with the biggest impact. The `IndexManager` stub already exists; you just need to hook it into `BPlusTree`. Once that's done, everything else unlocks.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,15 +5,17 @@ Each phase builds on the previous. Every phase is independently demo-able in an 
 
 ---
 
-## Phase 1: Persist the B+ Tree  (≈ 2-3 coding sessions)
+## ✅ Phase 1: Persist the B+ Tree (COMPLETE)
 **What:** Wire up `IndexManager` so the B+ tree survives process restarts.
-**Why:** Currently the tree is in-memory — lose power, lose the index. This is the #1 gap.
+**Why:** The tree was in-memory — lose power, lose the index. This was the #1 gap.
 
-**Plan:**
-- `BPlusTree` gets a `save()` / `load(IndexManager&)` or a constructor that takes `IndexManager&` and auto-loads
-- On every insert/remove/update, persist the affected nodes (or lazy-write on flush)
-- `IndexManager` already has `loadNode`, `saveNode`, `allocateNodeID` — just needs connecting
-- Add a test that inserts 20 keys, destroys the tree, reloads from disk, asserts all keys survive
+**Done:**
+- `BPlusTree(IndexManager&)` constructor auto-loads from disk if data exists
+- `save()` / `load()` persist and reconstruct the full tree (including `next_leaf` chain)
+- Every `insert`/`update`/`remove` triggers an automatic full-tree save
+- `IndexManager` header stores `root_node_id` so the root is always known after restarts
+- Empty tree handled: `root_node_id = -1` on disk
+- 10 tests cover: 20-key round-trip, range scan, getAll, update, remove, empty tree
 
 **Systems concept taught:** Serialization, disk layout, the memory-storage boundary.
 
@@ -107,6 +109,13 @@ Each phase builds a sentence you can say in an interview. No fluff.
 
 ---
 
-## Recommendation
+## Progress
 
-Start with **Phase 1** — it's the smallest change with the biggest impact. The `IndexManager` stub already exists; you just need to hook it into `BPlusTree`. Once that's done, everything else unlocks.
+| Phase | Status |
+|-------|--------|
+| 1 — Persist the B+ Tree | ✅ Done |
+| 2 — Buffer Pool | 🔜 Next |
+| 3 — Write-Ahead Log | ⏳ |
+| 4 — Simple Transactions | ⏳ |
+| 5 — SQL Frontend | ⏳ |
+| 6 — Benchmarking & Polish | ⏳ |

--- a/include/bplustree.hpp
+++ b/include/bplustree.hpp
@@ -1,12 +1,14 @@
 #pragma once
 
 #include "node.hpp"
+#include "indexmanager.hpp"
 #include <memory>
 
 
 class BPlusTree {
 public:
     BPlusTree();
+    explicit BPlusTree(IndexManager& im);
 
     void insert(const Key& key, int page_id, int slot_id);
     void printTree() const;
@@ -15,8 +17,19 @@ public:
     std::vector<std::pair<Key, RID>> rangeScan(const Key& low, const Key& high);
     std::vector<std::pair<Key, RID>> getAllKeyRIDPairs() const;
     bool remove(const Key& key);
+
+    void save();
+    void load();
+
 private:
     std::shared_ptr<BPlusTreeNode> root;
+    IndexManager* im;
+
+    void maybeSave();
+    void saveRecursive(std::shared_ptr<BPlusTreeNode> node);
+    std::shared_ptr<BPlusTreeNode> loadRecursive(int node_id);
+    void collectLeavesInOrder(std::shared_ptr<BPlusTreeNode> node,
+                              std::vector<std::shared_ptr<BPlusTreeNode>>& leaves);
 
     void propagateSeparatorUpdate(std::shared_ptr<BPlusTreeNode> child, const Key& old_sep, const Key& new_sep);
 

--- a/include/indexmanager.hpp
+++ b/include/indexmanager.hpp
@@ -14,11 +14,17 @@ public:
     int allocateNodeID();
     void flush();
 
+    bool hasData() const;
+    void setRootNodeID(int id);
+    int getRootNodeID() const;
+
 private:
     std::fstream index_file;
     std::string filename;
     int next_node_id;
+    int root_node_id;
 
     void openFile();
     void ensureFileSize(std::size_t size);
+    std::size_t nodeOffset(int node_id) const;
 };

--- a/src/bplustree.cpp
+++ b/src/bplustree.cpp
@@ -6,8 +6,18 @@
 #include <iostream>
 
 
-BPlusTree::BPlusTree() {
+BPlusTree::BPlusTree()
+    : im(nullptr) {
     root = std::make_shared<BPlusTreeNode>(true);  // root is leaf at start
+}
+
+BPlusTree::BPlusTree(IndexManager& indexManager)
+    : im(&indexManager) {
+    if (im->hasData()) {
+        load();
+    } else {
+        root = std::make_shared<BPlusTreeNode>(true);
+    }
 }
 
 std::shared_ptr<BPlusTreeNode> BPlusTree::findLeafNode(const Key& key) {
@@ -47,6 +57,8 @@ void BPlusTree::insert(const Key& key, int page_id, int slot_id) {
             insertInternal(split_key, leaf, new_leaf);
         }
     }
+
+    maybeSave();
 }
 
 void BPlusTree::insertInternal(const Key& key,
@@ -93,7 +105,9 @@ std::optional<RID> BPlusTree::search(const Key& key) {
 bool BPlusTree::update(const Key& key, int new_page_id, int new_slot_id) {
     auto leaf = findLeafNode(key);
     if (!leaf) return false;
-    return leaf->updateInLeaf(key, new_page_id, new_slot_id);
+    bool ok = leaf->updateInLeaf(key, new_page_id, new_slot_id);
+    if (ok) maybeSave();
+    return ok;
 }
 
 std::vector<std::pair<Key, RID>> 
@@ -216,6 +230,7 @@ bool BPlusTree::remove(const Key& key) {
     // Root special case
     if (leaf == root && leaf->keys.empty()) {
         root = nullptr;
+        maybeSave();
         return true;
     }
 
@@ -224,6 +239,7 @@ bool BPlusTree::remove(const Key& key) {
         handleLeafUnderflow(leaf);
     }
 
+    maybeSave();
     return true;
 }
 
@@ -382,4 +398,79 @@ void BPlusTree::propagateSeparatorUpdate(std::shared_ptr<BPlusTreeNode> child, c
         }
     }
     propagateSeparatorUpdate(parent, old_sep, new_sep);
+}
+
+void BPlusTree::maybeSave() {
+    if (im) {
+        save();
+    }
+}
+
+void BPlusTree::save() {
+    if (!root) {
+        im->setRootNodeID(-1);
+        im->flush();
+        return;
+    }
+    saveRecursive(root);
+    im->setRootNodeID(root->node_id);
+    im->flush();
+}
+
+void BPlusTree::saveRecursive(std::shared_ptr<BPlusTreeNode> node) {
+    if (!node) return;
+    if (node->node_id == -1) {
+        node->node_id = im->allocateNodeID();
+    }
+    if (!node->is_leaf) {
+        for (auto& child : node->children) {
+            saveRecursive(child);
+        }
+    }
+    im->saveNode(node);
+}
+
+std::shared_ptr<BPlusTreeNode> BPlusTree::loadRecursive(int node_id) {
+    auto node = im->loadNode(node_id);
+    if (!node->is_leaf) {
+        for (auto& child : node->children) {
+            if (child && child->node_id != -1) {
+                auto loaded_child = loadRecursive(child->node_id);
+                loaded_child->parent = node;
+                child = loaded_child;
+            }
+        }
+    }
+    return node;
+}
+
+void BPlusTree::collectLeavesInOrder(std::shared_ptr<BPlusTreeNode> node,
+                                     std::vector<std::shared_ptr<BPlusTreeNode>>& leaves) {
+    if (!node) return;
+    if (node->is_leaf) {
+        leaves.push_back(node);
+    } else {
+        for (auto& child : node->children) {
+            collectLeavesInOrder(child, leaves);
+        }
+    }
+}
+
+void BPlusTree::load() {
+    int root_id = im->getRootNodeID();
+    if (root_id < 0) {
+        root = std::make_shared<BPlusTreeNode>(true);
+        return;
+    }
+    root = loadRecursive(root_id);
+
+    // Reconstruct next_leaf chain
+    std::vector<std::shared_ptr<BPlusTreeNode>> leaves;
+    collectLeavesInOrder(root, leaves);
+    for (size_t i = 0; i + 1 < leaves.size(); ++i) {
+        leaves[i]->next_leaf = leaves[i + 1];
+    }
+    if (!leaves.empty()) {
+        leaves.back()->next_leaf = nullptr;
+    }
 }

--- a/src/indexmanager.cpp
+++ b/src/indexmanager.cpp
@@ -5,8 +5,17 @@
 
 
 IndexManager::IndexManager(const std::string& index_filename)
-    : filename(index_filename), next_node_id(0) {
+    : filename(index_filename), next_node_id(0), root_node_id(-1) {
     openFile();
+    // Read header (root_node_id) from offset 0 if file has data
+    index_file.seekg(0, std::ios::beg);
+    if (index_file.good()) {
+        index_file.read(reinterpret_cast<char*>(&root_node_id), sizeof(int));
+        if (!index_file.good()) {
+            root_node_id = -1;
+            index_file.clear(); // stream may have failed on empty file
+        }
+    }
 }
 
 IndexManager::~IndexManager() {
@@ -39,7 +48,11 @@ void IndexManager::openFile() {
     index_file.seekg(0, std::ios::end);
     std::size_t file_size = index_file.tellg();
 
-    next_node_id = static_cast<int>(file_size / PAGE_SIZE);
+    if (file_size > PAGE_SIZE) {
+        next_node_id = static_cast<int>((file_size - PAGE_SIZE) / PAGE_SIZE);
+    } else {
+        next_node_id = 0;
+    }
 }
 
 int IndexManager::allocateNodeID() {
@@ -62,7 +75,7 @@ void IndexManager::ensureFileSize(std::size_t size) {
 void IndexManager::saveNode(const std::shared_ptr<BPlusTreeNode>& node) {
     auto buffer = node->serialize();
 
-    std::size_t offset = static_cast<std::size_t>(node->node_id) * PAGE_SIZE;
+    std::size_t offset = nodeOffset(node->node_id);
     ensureFileSize(offset + PAGE_SIZE);
 
     if (buffer.size() > PAGE_SIZE) {
@@ -80,7 +93,7 @@ void IndexManager::saveNode(const std::shared_ptr<BPlusTreeNode>& node) {
 }
 
 std::shared_ptr<BPlusTreeNode> IndexManager::loadNode(int node_id) {
-    std::size_t offset = static_cast<std::size_t>(node_id) * PAGE_SIZE;
+    std::size_t offset = nodeOffset(node_id);
     ensureFileSize(offset + PAGE_SIZE);
 
     index_file.seekg(offset, std::ios::beg);
@@ -93,6 +106,25 @@ std::shared_ptr<BPlusTreeNode> IndexManager::loadNode(int node_id) {
     node->node_id = node_id;
 
     return node;
+}
+
+bool IndexManager::hasData() const {
+    return root_node_id >= 0;
+}
+
+void IndexManager::setRootNodeID(int id) {
+    root_node_id = id;
+    index_file.seekp(0, std::ios::beg);
+    index_file.write(reinterpret_cast<const char*>(&root_node_id), sizeof(int));
+    index_file.flush();
+}
+
+int IndexManager::getRootNodeID() const {
+    return root_node_id;
+}
+
+std::size_t IndexManager::nodeOffset(int node_id) const {
+    return PAGE_SIZE + static_cast<std::size_t>(node_id) * PAGE_SIZE;
 }
 
 

--- a/test.cpp
+++ b/test.cpp
@@ -6,6 +6,7 @@
 #include "page.hpp"
 #include "node.hpp"
 #include "bplustree.hpp"
+#include "indexmanager.hpp"
 #include "catalogmanager.hpp"
 #include "pagemanager.hpp"
 #include "recordmanager.hpp"
@@ -516,6 +517,121 @@ static void test_table_insert_mismatch() {
     std::remove(file.c_str());
 }
 
+// ─── BPlusTree Persistence ───────────────────────────────────────────────────
+
+static void test_bpt_persist_20() {
+    const std::string file = "bt_20.db";
+    std::remove(file.c_str());
+    {
+        TEST("insert 20 keys and persist") {
+            IndexManager im(file);
+            BPlusTree t(im);
+            for (int i = 0; i < 20; i++) {
+                t.insert(Key(std::to_string(i)), i, i * 10);
+            }
+        } END_TEST;
+    }
+    {
+        TEST("reload and verify all 20 keys survive") {
+            IndexManager im(file);
+            BPlusTree t(im);
+            for (int i = 0; i < 20; i++) {
+                auto r = t.search(Key(std::to_string(i)));
+                assert(r.has_value());
+                assert(r->page_id == i);
+                assert(r->slot_id == i * 10);
+            }
+        } END_TEST;
+    }
+    {
+        TEST("reload and range scan") {
+            IndexManager im(file);
+            BPlusTree t(im);
+            auto results = t.rangeScan(Key("5"), Key("9"));
+            assert(results.size() == 5);
+        } END_TEST;
+    }
+    {
+        TEST("reload and getAll") {
+            IndexManager im(file);
+            BPlusTree t(im);
+            assert(t.getAllKeyRIDPairs().size() == 20);
+        } END_TEST;
+    }
+    std::remove(file.c_str());
+}
+
+static void test_bpt_persist_update() {
+    const std::string file = "bt_update.db";
+    std::remove(file.c_str());
+    {
+        TEST("insert, update, persist") {
+            IndexManager im(file);
+            BPlusTree t(im);
+            t.insert(Key("x"), 1, 1);
+            t.insert(Key("y"), 2, 2);
+            assert(t.update(Key("x"), 99, 99));
+        } END_TEST;
+    }
+    {
+        TEST("reload and verify update survived") {
+            IndexManager im(file);
+            BPlusTree t(im);
+            auto r = t.search(Key("x"));
+            assert(r.has_value());
+            assert(r->page_id == 99);
+            assert(r->slot_id == 99);
+            assert(t.search(Key("y"))->page_id == 2);
+        } END_TEST;
+    }
+    std::remove(file.c_str());
+}
+
+static void test_bpt_persist_remove() {
+    const std::string file = "bt_remove.db";
+    std::remove(file.c_str());
+    {
+        TEST("insert, remove, persist") {
+            IndexManager im(file);
+            BPlusTree t(im);
+            t.insert(Key("keep"), 0, 0);
+            t.insert(Key("gone"), 1, 1);
+            assert(t.remove(Key("gone")));
+        } END_TEST;
+    }
+    {
+        TEST("reload and verify remove survived") {
+            IndexManager im(file);
+            BPlusTree t(im);
+            assert(t.search(Key("keep")).has_value());
+            assert(!t.search(Key("gone")).has_value());
+        } END_TEST;
+    }
+    std::remove(file.c_str());
+}
+
+static void test_bpt_persist_empty() {
+    const std::string file = "bt_empty.db";
+    std::remove(file.c_str());
+    {
+        TEST("save empty tree") {
+            IndexManager im(file);
+            BPlusTree t(im);
+            t.insert(Key("a"), 0, 0);
+            t.remove(Key("a"));
+        } END_TEST;
+    }
+    {
+        TEST("reload empty tree") {
+            IndexManager im(file);
+            BPlusTree t(im);
+            assert(!t.search(Key("a")).has_value());
+            assert(t.getAllKeyRIDPairs().empty());
+        } END_TEST;
+    }
+    std::remove(file.c_str());
+}
+
 // ─── Main ────────────────────────────────────────────────────────────────────
 
 int main() {
@@ -531,6 +647,9 @@ int main() {
     test_pm_alloc(); test_pm_readback(); test_pm_multi();
     std::cout << "=== RecordManager ===\n";
     test_rm_basic(); test_rm_multi();
+    std::cout << "=== BPlusTree Persistence ===\n";
+    test_bpt_persist_20(); test_bpt_persist_update(); test_bpt_persist_remove(); test_bpt_persist_empty();
+
     std::cout << "=== Table ===\n";
     test_table_basic(); test_table_delete(); test_table_insert_mismatch();
 


### PR DESCRIPTION
## Description

Wire up `IndexManager` (previously dead code) so the B+ tree survives process restarts. The tree now persists to disk automatically on every insert/update/remove, and reloads on construction.

## Changes

- `BPlusTree(IndexManager&)` constructor � auto-loads from disk if data exists
- `save()` / `load()` � persist and reconstruct full tree (including `next_leaf` chain)
- Auto-save on every `insert`/`update`/`remove`
- `IndexManager` gets a `root_node_id` header (first 4 bytes of file) so root is always known
- Empty tree: `root_node_id = -1` on disk
- Added `src/indexmanager.cpp` to CMake build

## How Has This Been Tested?

- [x] `cmake --build build` succeeds
- [x] `build\db_engine_test.exe` passes all 88 tests
- [x] Pre-existing tests remain green

New tests (10 cases):
- 20-key round-trip: insert ? destroy ? reload ? verify all keys survive
- Range scan and getAll on reloaded tree
- Update persistence
- Remove persistence
- Empty tree persistence

## Documentation Updated

- ROADMAP.md � Phase 1 marked complete, progress table added
- CODEGUIDE.md � IndexManager no longer "NOT USED", persistence gotchas added
- README.md � disk persistence added to features
