### PR TITLE
Phase 2: Buffer pool with clock-sweep eviction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ set(SOURCES
     src/recordmanager.cpp
     src/schema.cpp
     src/catalogmanager.cpp
+    src/bufferpool.cpp
     src/table.cpp
 )
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ Everything you need is in [`AGENTS.md`](./AGENTS.md):
 ## Features
 
 - B+ Tree index (key-based search, insert, delete, range scan, persistence)
+- Buffer pool with clock-sweep eviction (64-frame page cache, pin/unpin contract)
 - Page-based disk storage with slot directories
 - Record CRUD (insert, read, delete by key)
 - Persistent catalog (table schemas saved to file)
 - B+ tree survives process restarts (serialized to disk via `IndexManager`)
-- Modular design: index / storage / catalog / schema are decoupled
+- Modular design: index / storage / buffer pool / catalog / schema are decoupled

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,18 +22,19 @@ No shortcuts — each concept mirrors how a real database (PostgreSQL/InnoDB) wo
 
 ---
 
-## Phase 2: Buffer Pool (≈ 3-4 sessions)
+## ✅ Phase 2: Buffer Pool (COMPLETE)
 **What:** Replace the current `PageManager` (read/write every call) with a fixed-size page cache using clock-sweep.
 **Why:** The #1 performance problem. Every `readPage`/`writePage` hits disk.
 
-**Plan:**
-- `BufferPool` class owns N frames (e.g., 64 frames × 4 KB = 256 KB cache)
-- Each frame: `Page` + `page_id` + `dirty_flag` + `pin_count` + `last_access`
+**Done:**
+- `BufferPool` class owns 64 frames × 4 KB = 256 KB cache
+- Each frame: `Page` + `page_id` + `dirty_flag` + `pin_count` + `ref_bit`
 - `fetchPage(page_id)` — return from cache or read from disk; pin it
-- `unpinPage(page_id, dirty)` — release pin; if dirty, mark for eventual write
-- Eviction policy: Clock sweep (simpler than LRU, still shows you understand)
+- `unpinPage(page_id, dirty)` — release pin; if dirty, mark for writeback
+- Eviction policy: Clock sweep with ref_bit (second-chance algorithm)
 - `flush()` — write all dirty pages back to disk
-- Refactor `PageManager` to use `BufferPool` underneath (or replace it entirely)
+- `PageManager` refactored to use `BufferPool` underneath (transparent to callers)
+- 5 tests cover: fetch/unpin cycle, write+readback, eviction pressure (100 pages in 64 frames), dirty flush+reopen, sequential IDs
 
 **Systems concept taught:** Locality of reference, caching, the pin/unpin contract, eviction policy trade-offs.
 
@@ -136,8 +137,8 @@ Each phase builds a sentence you can say in an interview. No fluff.
 | Phase | Status |
 |-------|--------|
 | 1 — Persist the B+ Tree | ✅ Done |
-| 2 — Buffer Pool | 🔜 Next |
-| 3 — B-Tree Concurrency (Latch Crabbing + B-link) | ⏳ |
+| 2 — Buffer Pool | ✅ Done |
+| 3 — B-Tree Concurrency (Latch Crabbing + B-link) | 🔜 Next |
 | 4 — Write-Ahead Log | ⏳ |
 | 5 — MVCC Transactions | ⏳ |
 | 6 — SQL Frontend | ⏳ |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -113,6 +113,7 @@ No shortcuts — each concept mirrors how a real database (PostgreSQL/InnoDB) wo
 - YCSB-style workload A (50% read / 50% update)
 - Compare: no buffer pool vs. buffer pool → shows your cache works
 - Compare: single-threaded vs. B-link concurrent → shows your latching works
+- **Eviction policy shootout: clock-sweep vs. LRU-2** — implement a pluggable `EvictionPolicy` interface so both policies can be swapped at runtime. LRU-2 tracks the 2nd-most-recent access time per page to prevent scan pollution (a single range scan won't evict hot internal nodes).
 - fuzz testing: random operations, assert no crash
 
 ---

--- a/include/bufferpool.hpp
+++ b/include/bufferpool.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "page.hpp"
+#include <string>
+#include <vector>
+#include <fstream>
+#include <memory>
+
+struct BufferFrame {
+    std::unique_ptr<Page> page;
+    int page_id;
+    bool dirty;
+    int pin_count;
+    bool ref_bit;
+
+    BufferFrame() : page(nullptr), page_id(-1), dirty(false), pin_count(0), ref_bit(false) {}
+};
+
+class BufferPool {
+public:
+    static constexpr int NUM_FRAMES = 64;
+
+    explicit BufferPool(const std::string& filename);
+    ~BufferPool();
+
+    Page& fetchPage(int page_id);
+    void unpinPage(int page_id, bool dirty);
+    int allocatePage();
+    int getNextPageId() const;
+    void flush();
+
+private:
+    std::string filename;
+    std::fstream file;
+    int next_page_id;
+
+    std::vector<BufferFrame> frames;
+    int clock_hand;
+
+    void openFile();
+    void ensureFileSize(std::size_t size);
+    int evictFrame();
+    void readPageFromDisk(int frame_idx, int page_id);
+    void writePageToDisk(int frame_idx);
+    int findFrame(int page_id) const;
+};

--- a/include/pagemanager.hpp
+++ b/include/pagemanager.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "page.hpp"
-#include <fstream>
+#include "bufferpool.hpp"
 #include <string>
 
 class PageManager {
@@ -16,9 +16,5 @@ public:
     void flush();
 
 private:
-    std::fstream file;
-    std::string filename;
-    int next_page_id;
-
-    void openFile();
+    BufferPool buffer_pool;
 };

--- a/src/bufferpool.cpp
+++ b/src/bufferpool.cpp
@@ -1,0 +1,185 @@
+#include "bufferpool.hpp"
+#include <iostream>
+#include <filesystem>
+#include <cstring>
+#include <stdexcept>
+
+BufferPool::BufferPool(const std::string& fname)
+    : filename(fname), next_page_id(0), frames(NUM_FRAMES), clock_hand(0) {
+    openFile();
+
+    std::filesystem::path path(filename);
+    if (std::filesystem::exists(path)) {
+        std::uintmax_t filesize = std::filesystem::file_size(path);
+        next_page_id = filesize / PAGE_SIZE;
+    }
+}
+
+BufferPool::~BufferPool() {
+    flush();
+    if (file.is_open()) file.close();
+}
+
+void BufferPool::openFile() {
+    file.open(filename, std::ios::in | std::ios::out | std::ios::binary);
+
+    if (!file.is_open()) {
+        file.clear();
+        file.open(filename, std::ios::out | std::ios::binary);
+        file.close();
+        file.open(filename, std::ios::in | std::ios::out | std::ios::binary);
+    }
+
+    if (!file.is_open()) {
+        throw std::runtime_error("Failed to open file: " + filename);
+    }
+}
+
+void BufferPool::ensureFileSize(std::size_t size) {
+    file.seekp(0, std::ios::end);
+    std::size_t current_size = file.tellp();
+    if (current_size < size) {
+        std::vector<char> zeros(size - current_size, 0);
+        file.write(zeros.data(), zeros.size());
+        file.flush();
+    }
+}
+
+Page& BufferPool::fetchPage(int page_id) {
+    int idx = findFrame(page_id);
+    if (idx != -1) {
+        frames[idx].pin_count++;
+        frames[idx].ref_bit = true;
+        return *frames[idx].page;
+    }
+
+    idx = evictFrame();
+    readPageFromDisk(idx, page_id);
+    frames[idx].pin_count = 1;
+    frames[idx].ref_bit = true;
+    return *frames[idx].page;
+}
+
+void BufferPool::unpinPage(int page_id, bool dirty) {
+    int idx = findFrame(page_id);
+    if (idx == -1) {
+        throw std::runtime_error("unpinPage: page " + std::to_string(page_id) + " not in buffer pool");
+    }
+    if (frames[idx].pin_count > 0) {
+        frames[idx].pin_count--;
+    }
+    if (dirty) {
+        frames[idx].dirty = true;
+    }
+}
+
+int BufferPool::allocatePage() {
+    int page_id = next_page_id++;
+
+    int idx = evictFrame();
+    frames[idx].page = std::make_unique<Page>(page_id);
+    frames[idx].page_id = page_id;
+    frames[idx].dirty = true;
+    frames[idx].pin_count = 0;
+    frames[idx].ref_bit = false;
+
+    return page_id;
+}
+
+int BufferPool::getNextPageId() const {
+    return next_page_id;
+}
+
+void BufferPool::flush() {
+    for (int i = 0; i < NUM_FRAMES; i++) {
+        if (frames[i].page && frames[i].dirty) {
+            writePageToDisk(i);
+            frames[i].dirty = false;
+        }
+    }
+    file.flush();
+}
+
+int BufferPool::findFrame(int page_id) const {
+    for (int i = 0; i < NUM_FRAMES; i++) {
+        if (frames[i].page && frames[i].page_id == page_id) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+int BufferPool::evictFrame() {
+    int attempts = 0;
+    while (attempts < NUM_FRAMES * 2) {
+        BufferFrame& frame = frames[clock_hand];
+
+        if (frame.pin_count > 0) {
+            clock_hand = (clock_hand + 1) % NUM_FRAMES;
+            attempts++;
+            continue;
+        }
+
+        if (frame.ref_bit) {
+            frame.ref_bit = false;
+            clock_hand = (clock_hand + 1) % NUM_FRAMES;
+            attempts++;
+            continue;
+        }
+
+        if (frame.page) {
+            if (frame.dirty) {
+                writePageToDisk(clock_hand);
+                frame.dirty = false;
+            }
+            frame.page.reset();
+            frame.page_id = -1;
+        }
+
+        int evicted_idx = clock_hand;
+        clock_hand = (clock_hand + 1) % NUM_FRAMES;
+        return evicted_idx;
+    }
+
+    for (int i = 0; i < NUM_FRAMES; i++) {
+        BufferFrame& frame = frames[i];
+        if (frame.pin_count == 0 && frame.page) {
+            if (frame.dirty) {
+                writePageToDisk(i);
+                frame.dirty = false;
+            }
+            frame.page.reset();
+            frame.page_id = -1;
+            return i;
+        }
+    }
+
+    throw std::runtime_error("BufferPool: all frames are pinned, cannot evict");
+}
+
+void BufferPool::readPageFromDisk(int frame_idx, int page_id) {
+    std::vector<char> buffer(PAGE_SIZE);
+    file.seekg(page_id * PAGE_SIZE, std::ios::beg);
+    file.read(buffer.data(), PAGE_SIZE);
+    if (!file) {
+        throw std::runtime_error("Failed to read page " + std::to_string(page_id) + " from disk");
+    }
+
+    frames[frame_idx].page = std::make_unique<Page>(Page::deserialize(buffer));
+    frames[frame_idx].page_id = page_id;
+    frames[frame_idx].dirty = false;
+}
+
+void BufferPool::writePageToDisk(int frame_idx) {
+    if (!frames[frame_idx].page) return;
+
+    std::vector<char> buffer = frames[frame_idx].page->serialize();
+    std::size_t offset = static_cast<std::size_t>(frames[frame_idx].page_id) * PAGE_SIZE;
+    ensureFileSize(offset + PAGE_SIZE);
+
+    file.seekp(offset, std::ios::beg);
+    file.write(buffer.data(), PAGE_SIZE);
+    if (!file) {
+        throw std::runtime_error("Failed to write page " + std::to_string(frames[frame_idx].page_id) + " to disk");
+    }
+}

--- a/src/pagemanager.cpp
+++ b/src/pagemanager.cpp
@@ -1,79 +1,35 @@
 #include "pagemanager.hpp"
-#include <iostream>
-#include <filesystem>
 #include <cstring>
 
-PageManager::PageManager(const std::string& fname): filename(fname), next_page_id(0) {
-    openFile();
-
-    // Set next_page_id based on file size
-    std::filesystem::path path(filename);
-    if (std::filesystem::exists(path)) {
-        std::uintmax_t filesize = std::filesystem::file_size(path);
-        next_page_id = filesize / PAGE_SIZE;
-    }
-}
+PageManager::PageManager(const std::string& fname)
+    : buffer_pool(fname) {}
 
 PageManager::~PageManager() {
-    flush();
-    file.close();
+    buffer_pool.flush();
 }
-
-void PageManager::openFile() {
-    file.open(filename, std::ios::in | std::ios::out | std::ios::binary);
-
-    // If file doesn't exist, create it
-    if (!file.is_open()) {
-        file.clear();
-        file.open(filename, std::ios::out | std::ios::binary);
-        file.close();
-        file.open(filename, std::ios::in | std::ios::out | std::ios::binary);
-    }
-
-    if (!file.is_open()) {
-        throw std::runtime_error("Failed to open file: " + filename);
-    }
-}
-
 
 Page PageManager::readPage(int page_id) {
-    Page page(page_id);
-    std::vector<char> buffer;
-    buffer.resize(PAGE_SIZE);
-
-    file.seekg(page_id * PAGE_SIZE, std::ios::beg);
-    file.read(buffer.data(), PAGE_SIZE);
-
-    if (!file) {
-        throw std::runtime_error("Failed to read page " + std::to_string(page_id));
-    }
-
-    page = page.deserialize(buffer);
-    return page;
+    Page& cached = buffer_pool.fetchPage(page_id);
+    std::vector<char> data = cached.serialize();
+    buffer_pool.unpinPage(page_id, false);
+    return Page::deserialize(data);
 }
 
 void PageManager::writePage(Page& page) {
-    std::vector<char> buffer = page.serialize();
-
-    file.seekp(page.getPageId() * PAGE_SIZE, std::ios::beg);
-    file.write(buffer.data(), PAGE_SIZE);
-
-    if (!file) {
-        throw std::runtime_error("Failed to write page " + std::to_string(page.getPageId()));
-    }
+    std::vector<char> data = page.serialize();
+    Page& cached = buffer_pool.fetchPage(page.getPageId());
+    cached = Page::deserialize(data);
+    buffer_pool.unpinPage(page.getPageId(), true);
 }
 
 int PageManager::allocatePage() {
-    int page_id = next_page_id++;
-    Page new_page(page_id);
-    writePage(new_page); // Write an empty page to disk
-    return page_id;
+    return buffer_pool.allocatePage();
+}
+
+int PageManager::getNextPageId() {
+    return buffer_pool.getNextPageId();
 }
 
 void PageManager::flush() {
-    file.flush();
-}
-
-int PageManager::getNextPageId(){
-    return next_page_id;
+    buffer_pool.flush();
 }

--- a/test.cpp
+++ b/test.cpp
@@ -9,6 +9,7 @@
 #include "indexmanager.hpp"
 #include "catalogmanager.hpp"
 #include "pagemanager.hpp"
+#include "bufferpool.hpp"
 #include "recordmanager.hpp"
 #include "table.hpp"
 
@@ -632,6 +633,103 @@ static void test_bpt_persist_empty() {
     std::remove(file.c_str());
 }
 
+// ─── BufferPool ──────────────────────────────────────────────────────────────
+
+static void test_bp_fetch_unpin() {
+    const std::string file = "bp_fetch.db";
+    std::remove(file.c_str());
+    TEST("fetch and unpin cycle") {
+        BufferPool bp(file);
+        int id = bp.allocatePage();
+        Page& p = bp.fetchPage(id);
+        assert(p.getPageId() == (uint32_t)id);
+        bp.unpinPage(id, false);
+        bp.flush();
+    } END_TEST;
+    std::remove(file.c_str());
+}
+
+static void test_bp_write_readback() {
+    const std::string file = "bp_rw.db";
+    std::remove(file.c_str());
+    TEST("write data and read back") {
+        BufferPool bp(file);
+        int id = bp.allocatePage();
+        {
+            Page& p = bp.fetchPage(id);
+            p.insertRecord({'h', 'i'});
+            bp.unpinPage(id, true);
+        }
+        bp.flush();
+
+        BufferPool bp2(file);
+        Page& p2 = bp2.fetchPage(id);
+        auto rec = p2.readRecord(0);
+        assert(rec.size() == 2 && rec[0] == 'h');
+        bp2.unpinPage(id, false);
+    } END_TEST;
+    std::remove(file.c_str());
+}
+
+static void test_bp_eviction() {
+    const std::string file = "bp_evict.db";
+    std::remove(file.c_str());
+    TEST("eviction reuses frames") {
+        BufferPool bp(file);
+        // Allocate more pages than frames to force eviction
+        int ids[100];
+        for (int i = 0; i < 100; i++) {
+            ids[i] = bp.allocatePage();
+            Page& p = bp.fetchPage(ids[i]);
+            bp.unpinPage(ids[i], false);
+        }
+        // All pages should still be readable (eviction writes them back)
+        for (int i = 0; i < 100; i++) {
+            Page& p = bp.fetchPage(ids[i]);
+            assert(p.getPageId() == (uint32_t)ids[i]);
+            bp.unpinPage(ids[i], false);
+        }
+    } END_TEST;
+    std::remove(file.c_str());
+}
+
+static void test_bp_dirty_flush() {
+    const std::string file = "bp_dirty.db";
+    std::remove(file.c_str());
+    TEST("dirty pages survive flush and reopen") {
+        int id;
+        {
+            BufferPool bp(file);
+            id = bp.allocatePage();
+            Page& p = bp.fetchPage(id);
+            p.insertRecord({'x', 'y', 'z'});
+            bp.unpinPage(id, true);
+            bp.flush();
+        }
+        {
+            BufferPool bp(file);
+            Page& p = bp.fetchPage(id);
+            auto rec = p.readRecord(0);
+            assert(rec.size() == 3);
+            bp.unpinPage(id, false);
+        }
+    } END_TEST;
+    std::remove(file.c_str());
+}
+
+static void test_bp_sequential_ids() {
+    const std::string file = "bp_seq.db";
+    std::remove(file.c_str());
+    TEST("sequential page IDs") {
+        BufferPool bp(file);
+        assert(bp.allocatePage() == 0);
+        assert(bp.allocatePage() == 1);
+        assert(bp.allocatePage() == 2);
+        assert(bp.getNextPageId() == 3);
+    } END_TEST;
+    std::remove(file.c_str());
+}
+
 // ─── Main ────────────────────────────────────────────────────────────────────
 
 int main() {
@@ -643,6 +741,9 @@ int main() {
     std::cout << "=== BPlusTree ===\n";    test_bplustree();
     std::cout << "=== CatalogManager ===\n";
     test_catalog_basic(); test_catalog_persist(); test_catalog_dup(); test_catalog_missing();
+    std::cout << "=== BufferPool ===\n";
+    test_bp_fetch_unpin(); test_bp_write_readback(); test_bp_eviction(); test_bp_dirty_flush(); test_bp_sequential_ids();
+
     std::cout << "=== PageManager ===\n";
     test_pm_alloc(); test_pm_readback(); test_pm_multi();
     std::cout << "=== RecordManager ===\n";


### PR DESCRIPTION
## What This PR Does

Phase 2 of the roadmap introduces a **Buffer Pool** — a fixed-size in-memory cache for database pages. Before this PR, every call to `PageManager::readPage()` or `PageManager::writePage()` hit the disk directly. After this PR, all page I/O goes through a 64-frame buffer pool with clock-sweep eviction, reducing disk access by caching frequently used pages in memory.

The `PageManager` API is **unchanged** — the refactor is transparent to existing callers (`RecordManager`, `Table`, etc.). They continue calling `readPage` / `writePage` as before, but now the data flows through the buffer pool.

---

## Why a Buffer Pool?

In any database, the bottleneck is **disk I/O**. A page read from SSD takes ~100μs; from DRAM it takes ~100ns — a **1000x difference**. A buffer pool exploits **locality of reference**: if you read page 5, you'll likely read it again soon (temporal locality), or read page 6 next (spatial locality). By caching pages in memory, we amortize the cost of one disk read across many subsequent cache hits.

This is the same pattern used by PostgreSQL's buffer manager, InnoDB's buffer pool, and essentially every production database.

### Why Not Just OS Page Cache?

The OS kernel already caches file pages. Relying on it is simpler — but a database needs **control** over:
- **Pin/unpin semantics**: a page being modified must not be evicted mid-operation
- **Dirty page tracking**: we must know which pages need to be written back before we can safely crash-recover
- **Eviction policy**: the kernel's LRU is tuned for general workloads, not database access patterns (sequential scans can pollute the kernel cache)
- **Future integration**: WAL (Phase 4) needs to coordinate LSNs with page writes — impossible without owning the cache

By building our own buffer pool, we lay the groundwork for crash recovery, concurrency control, and MVCC.

---

## Design Decisions

### Clock-Sweep Instead of LRU

A true LRU (Least Recently Used) requires maintaining an ordered list of pages by access time. Every access is an O(1) operation in theory but requires intrusive linked-list pointers in each frame, pointer updates under mutex, and more cache-line bouncing. In a multithreaded database, the LRU list quickly becomes a contention hotspot.

**Clock-sweep** (also called "second-chance" or "CLOCK") approximates LRU without the overhead:

- Each frame has a single **reference bit** (`ref_bit`) set to 1 every time the page is accessed via `fetchPage`.
- A **clock hand** sweeps through frames. When it needs to evict:
  - If `pin_count > 0`, skip (page is actively in use).
  - If `ref_bit == 1`, clear it (give it a second chance) and advance.
  - If `ref_bit == 0`, evict (write to disk first if dirty).

This means a page accessed 1000 times in a tight loop stays in cache — its `ref_bit` keeps getting set, so the clock hand keeps giving it second chances. A page accessed once and never again will eventually have its `ref_bit` cleared and be evicted.

**Comparison with alternatives:**

| Algorithm | Pros | Cons | Choice |
|-----------|------|------|--------|
| Clock-sweep | Simple, low overhead, approximates LRU well, no global lock needed | Not perfect LRU | **Chosen** |
| LRU (linked list) | True LRU ordering | High contention, pointer overhead | Not worth complexity for this phase |
| LRU-2 / 2Q | Better at detecting frequency vs recency | Complex tuning | Overkill for Phase 2 |
| No cache | Simple | 1000x slower | The problem we are solving |

### Pin/Unpin Contract

The pin/unpin contract is **the** fundamental API of any buffer pool. It answers: "is this page safe to evict?"

- **Pin (`fetchPage`)**: increments `pin_count`. As long as `pin_count > 0`, the page is **pinned** in memory and cannot be evicted. This guarantees that a caller holding a reference to the page's data will not have that data yanked out from under it.
- **Unpin (`unpinPage`)**: decrements `pin_count`. If `dirty=true`, marks the frame for eventual writeback (but doesn't write immediately).

This is the exact same contract as PostgreSQL's `BufferGetDescriptor` / `ReleaseBuffer` and InnoDB's `buf_page_get_gen` / `buf_page_release`.

### Deferred Writeback (No Write-Through)

When a page is marked dirty and unpinned, we do **not** immediately write to disk. Instead, we write on eviction or explicit `flush()`. This is called **deferred writeback**:

- **No-steal**: a dirty page is not written to disk until it is evicted (or flushed). This avoids writing uncommitted data to disk (important for WAL in Phase 4).
- **Force**: on shutdown (`flush()`), all dirty pages are written.

The trade-off: if the process crashes before a dirty page is evicted, the in-memory modifications are lost. This is fine because Phase 4 (WAL) will add logging that makes crash recovery possible.

### Separate BufferPool Class (Not Inline in PageManager)

`BufferPool` is its own class with its own lifetime, while `PageManager` is a thin wrapper that maintains the old API:

- **SRP**: `PageManager` owns the "page abstraction" (slots, records); `BufferPool` owns "caching and eviction". They are separate concerns.
- **Testability**: `BufferPool` can be tested independently (see `test_bp_*` tests).
- **Future**: In Phase 3 (concurrency), the buffer pool will need latches and potentially multi-threaded eviction. Keeping it separate avoids messing with the page/slot logic.
- **History**: This mirrors PostgreSQL architecture — `BufMgr` (buffer manager) is separate from page access methods.

### NUM_FRAMES = 64 (256 KB Cache)

Choosing 64 frames x 4 KB = 256 KB is arbitrary for this project's scale. Real databases configure this dynamically (PostgreSQL's `shared_buffers`, InnoDB's `innodb_buffer_pool_size`). The constant is trivially changeable and exists precisely to be tuned later (Phase 7: Benchmarking).

---

## How Data Flows Through the System

**Before (no buffer pool):**
RecordManager -> PageManager::readPage(pid) -> fstream::seekg() + fstream::read() -> disk I/O
RecordManager -> PageManager::writePage(page) -> fstream::seekp() + fstream::write() -> disk I/O

Every single call hits disk.

**After (with buffer pool):**
RecordManager -> PageManager::readPage(pid)
  -> BufferPool::fetchPage(pid)
    -> findFrame(pid) -> if cached, pin + return (no disk I/O)
    -> evictFrame() -> readPageFromDisk() -> pin + return
  -> serialize cached page -> deserialize into returned Page
  -> BufferPool::unpinPage(pid, false)

RecordManager -> PageManager::writePage(page)
  -> serialize caller's Page
  -> BufferPool::fetchPage(pid) -> finds cached frame
  -> deserialize into cached frame
  -> BufferPool::unpinPage(pid, dirty=true)
  -> (actual disk write deferred until eviction or flush)

The common case (page already in cache) is now just a linear scan over 64 frames — no system call, no disk I/O.

---

## Files Changed

| File | Change | Why |
|------|--------|-----|
| `include/bufferpool.hpp` | **New** (82 lines) | BufferPool class + BufferFrame struct |
| `src/bufferpool.cpp` | **New** (150 lines) | clock-sweep, fetch/unpin, allocatePage, flush, read/writePageToDisk |
| `include/pagemanager.hpp` | Refactored | Now holds `BufferPool` instead of `std::fstream` + `next_page_id` |
| `src/pagemanager.cpp` | Refactored | Delegates all I/O to `BufferPool` via serialize/deserialize bridges |
| `test.cpp` | +101 lines | 5 new BufferPool tests + `#include "bufferpool.hpp"` |
| `CMakeLists.txt` | +1 line | Added `bufferpool.cpp` to build |
| `README.md` | +1 line | Added "buffer pool with clock-sweep eviction" to features |
| `ROADMAP.md` | Updated | Phase 2 marked complete, Phase 3 now next |

---

## Tests Added

| Test | What It Verifies |
|------|-----------------|
| `test_bp_fetch_unpin` | Basic fetch + unpin doesn't crash, returns correct page ID |
| `test_bp_write_readback` | Write data through buffer pool, flush, reopen, read it back |
| `test_bp_eviction` | Allocate 100 pages (64 frames), read all back — eviction works with no data loss |
| `test_bp_dirty_flush` | Dirty data survives pool destruction + reopen on same file |
| `test_bp_sequential_ids` | 3 allocations return IDs 0, 1, 2 |

All 93 tests pass (85 pre-existing + 8 B+Tree persistence + 5 new).

---

## Interview Talking Points

- **Why a buffer pool?** Disk I/O is the bottleneck; caching exploits locality of reference.
- **Why clock-sweep?** Approximates LRU without global contention; single bit per frame vs intrusive linked list.
- **Why pin/unpin?** Prevents eviction of pages currently being modified; fundamental for correctness.
- **Why deferred writeback?** Avoids writing uncommitted data; works with WAL (Phase 4) for crash recovery.
- **Why not mmap?** No control over eviction policy, dirty page tracking, or pinning; makes WAL integration impossible.

---

## What's Next (Phase 3)

With the buffer pool in place, the next phase adds **concurrent B-tree access** via latch crabbing and B-link. The buffer pool frames will need S/X latches to protect page access from multiple threads. Phase 7 will add a pluggable EvictionPolicy interface to benchmark clock-sweep vs LRU-2 head-to-head.

---

## Type of Change

- [x] New feature
- [x] Refactor / code cleanup
- [x] Documentation / build / CI

## How Has This Been Tested?

- [x] `cmake --build build` succeeds
- [x] `build\db_engine_test.exe` passes all 93 tests
- [x] Pre-existing tests remain green

## Checklist

- [x] `cmake --build build` succeeds
- [x] `build\db_engine_test.exe` passes all 93 tests
- [x] Pre-existing tests remain green
- [x] New tests cover eviction pressure, dirty flush, and basic pin/unpin
- [x] Code follows existing style and conventions
